### PR TITLE
Remove same-origin from preview iframe

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
                         <div class="divider"></div>
                         <div id="previewContainer">
 				<div id="previewLabel">Live Preview</div>
-				<iframe id="previewFrame" sandbox="allow-scripts allow-same-origin"></iframe>
+				<iframe id="previewFrame" sandbox="allow-scripts"></iframe>
                         </div>
                         <div class="divider"></div>
                                 <div id="logContainer">


### PR DESCRIPTION
## Summary
- restrict preview iframe by dropping `allow-same-origin`

## Testing
- `node test_preview.js`

------
https://chatgpt.com/codex/tasks/task_e_6855787d52cc8331958c5a5278f18b9e