### PR TITLE
Fix cross-origin error when capturing iframe errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
                         <div class="divider"></div>
                         <div id="previewContainer">
 				<div id="previewLabel">Live Preview</div>
-				<iframe id="previewFrame" sandbox="allow-scripts"></iframe>
+                                <iframe id="previewFrame" sandbox="allow-scripts allow-same-origin"></iframe>
                         </div>
                         <div class="divider"></div>
                                 <div id="logContainer">


### PR DESCRIPTION
## Summary
- allow same-origin access for the preview iframe so the runtime error capture works

## Testing
- `git log -1 -p`

------
https://chatgpt.com/codex/tasks/task_e_68557dc271808331aafbb78b93e9c716