### PR TITLE
Handle screenshot errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -657,10 +657,13 @@ function showSpinner(show){ spinnerOverlay.style.display = show ? 'flex' : 'none
 			async function captureIframeScreenshot(){
 				let doc=preview.contentDocument;
 				if(!doc)return null;
-				try{
-					let canvas=await html2canvas(doc.body);
-					return canvas.toDataURL("image/png");
-				}catch(e){ log("Screenshot","Failed: "+e);}
+                                try{
+                                        let canvas = await html2canvas(doc.body);
+                                        return canvas.toDataURL("image/png");
+                                }catch(e){
+                                        log("Screenshot", e.message, null, {error:true});
+                                        alert("Screenshot failed: " + e.message);
+                                }
 				return null;
 			}
 		</script>


### PR DESCRIPTION
## Summary
- notify users when screenshot capture fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68579d006590833191330ceb571e61d5