### PR TITLE
Improve error logging for OpenAI API

### DIFF
--- a/index.html
+++ b/index.html
@@ -593,6 +593,7 @@ function showSpinner(show){ spinnerOverlay.style.display = show ? 'flex' : 'none
 				});
                                 let data = await res.json();
                                 if (!res.ok || !data.choices || !data.choices[0]) {
+                                        log(agent, JSON.stringify(data), null, {error:true});
                                         let errMsg = data.error?.message || "OpenAI API Error";
                                         log(agent, `ERROR: ${errMsg}`, null, {error:true});
                                         statusBar.textContent = `Error from OpenAI: ${errMsg}`;


### PR DESCRIPTION
## Summary
- log the raw API response when the OpenAI request fails

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6857a72934248331b7725deb1cba7a10