### PR TITLE
Fix screenshot capture with invalid CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -676,7 +676,11 @@ function showSpinner(show){ spinnerOverlay.style.display = show ? 'flex' : 'none
 				let doc=preview.contentDocument;
 				if(!doc)return null;
                                 try{
-                                        let canvas = await html2canvas(doc.body);
+                                        let canvas = await html2canvas(doc.body, {
+                                                onclone: cloned => {
+                                                        cloned.querySelectorAll('style').forEach(el => el.remove());
+                                                }
+                                        });
                                         return canvas.toDataURL("image/png");
                                 }catch(e){
                                         console.error("Screenshot failed:", e);


### PR DESCRIPTION
## Summary
- strip style tags from cloned DOM before taking screenshot to avoid parse errors

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_6857d9cc122c8331807b68c9af9f0522