### PR TITLE
Improve screenshot style parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -693,20 +693,18 @@ function showSpinner(show){ spinnerOverlay.style.display = show ? 'flex' : 'none
                                         let canvas = await html2canvas(doc.body, {
                                                 onclone: cloned => {
                                                         // remove <style> tags and clean inline styles
+                                                        const parser = document.createElement('div');
                                                         cloned.querySelectorAll('style').forEach(el => el.remove());
                                                         cloned.querySelectorAll('[style]').forEach(el => {
                                                                 const original = el.getAttribute('style');
                                                                 if(!original) return;
-                                                                const safe = [];
-                                                                original.split(';').forEach(r => {
-                                                                        const parts = r.split(':');
-                                                                        if(parts.length >= 2){
-                                                                                const prop = parts[0].trim();
-                                                                                const val = parts.slice(1).join(':').trim();
-                                                                                if(prop && val) safe.push(`${prop}: ${val}`);
-                                                                        }
-                                                                });
-                                                                el.setAttribute('style', safe.join('; '));
+                                                                try{
+                                                                        parser.style.cssText = '';
+                                                                        parser.style.cssText = original;
+                                                                        el.setAttribute('style', parser.style.cssText);
+                                                                }catch(err){
+                                                                        el.removeAttribute('style');
+                                                                }
                                                         });
                                                 }
                                         });


### PR DESCRIPTION
## Summary
- sanitize inline styles using DOM parsing instead of manual string logic
- avoid html2canvas errors on complex inline CSS

## Testing
- `npm install jsdom`
- `node - <<'NODE'
const {JSDOM} = require('jsdom');
const dom = new JSDOM('<div id="el" style="color: red; invalid:; width:calc(100% - 20px);"></div>');
const el = dom.window.document.getElementById('el');
let parser = dom.window.document.createElement('div');
try {
  parser.style.cssText = '';
  parser.style.cssText = el.getAttribute('style');
  el.setAttribute('style', parser.style.cssText);
  console.log('success:', el.getAttribute('style'));
} catch(err){
  console.log('error', err.message);
  el.removeAttribute('style');
  console.log('final style', el.getAttribute('style'));
}
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6857e00f13048331b6d73bf4438c34a7