### PR TITLE
Improve log toggle visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,8 +47,9 @@
 				background: #fff;
 				border: none;
 			}
-			#logContainer { max-width: 33vw; min-width: 350px; background: #181b20;}
-			#codeEditor { flex:1; width:100%; font-family:'JetBrains Mono',monospace; font-size:15px; background: #16191c; color:#e9e9e9; border:none; outline:none; padding:1rem;}
+                        #logContainer { max-width: 33vw; min-width: 350px; background: #181b20;}
+                        #logContent { flex:1; display:flex; flex-direction:column; overflow:auto; }
+                        #codeEditor { flex:1; width:100%; font-family:'JetBrains Mono',monospace; font-size:15px; background: #16191c; color:#e9e9e9; border:none; outline:none; padding:1rem;}
 			#debugLogList { flex:1; width:100%; background:#191b20; color:#b9e8ff; font-size:13px; font-family:monospace; border:none; padding:1rem; overflow:auto; }
 			#logHeader { padding: 0.6rem 1rem 0.3rem 1rem; font-weight: bold; letter-spacing:1px; background:#22262c; }
 			#editorLabel, #previewLabel { padding:0.6rem 1rem 0.3rem 1rem; font-weight:bold; letter-spacing:1px; background:#22262c;}
@@ -125,19 +126,21 @@
 				<iframe id="previewFrame" sandbox="allow-scripts allow-same-origin"></iframe>
 			</div>
 			<div class="divider"></div>
-			<div id="logContainer">
-				<div id="logHeader" style="display:flex; align-items:center;">
-					<span style="flex:1;">AI Debug Log</span>
-					<button id="toggleLogBtn" style="margin-right:1em;">Hide Log</button>
-					<button class="copyLogBtn">Copy Log</button>
-					<button class="downloadLogBtn">Download Log</button>
-				</div>
-				<div id="screenshotPreview" style="display:none; padding:0.5rem; text-align:center; border-bottom:1px solid #222; background:#111;">
-					<img style="max-width:100%; max-height:160px; border:1px solid #555; border-radius:4px; cursor:pointer;" />
-				</div>
-				<div id="planBox" style="display:none; white-space:pre-wrap; background:#1b1e23; border-bottom:1px solid #222; padding:0.5rem; font-size:0.9em; color:#b6e6ff;"></div>
-				<div id="debugLogList"></div>
-			</div>
+                        <div id="logContainer">
+                                <div id="logHeader" style="display:flex; align-items:center;">
+                                        <span style="flex:1;">AI Debug Log</span>
+                                        <button id="toggleLogBtn" style="margin-right:1em;">Hide Log</button>
+                                        <button class="copyLogBtn">Copy Log</button>
+                                        <button class="downloadLogBtn">Download Log</button>
+                                </div>
+                                <div id="logContent">
+                                        <div id="screenshotPreview" style="display:none; padding:0.5rem; text-align:center; border-bottom:1px solid #222; background:#111;">
+                                                <img style="max-width:100%; max-height:160px; border:1px solid #555; border-radius:4px; cursor:pointer;" />
+                                        </div>
+                                        <div id="planBox" style="display:none; white-space:pre-wrap; background:#1b1e23; border-bottom:1px solid #222; padding:0.5rem; font-size:0.9em; color:#b6e6ff;"></div>
+                                        <div id="debugLogList"></div>
+                                </div>
+                        </div>
 		</main>
 		<div id="statusBar">Ready.</div>
 		<div id="screenshotModal" style="display:none; position:fixed; top:0; left:0; right:0; bottom:0; background:#000a; align-items:center; justify-content:center; z-index:1000;">
@@ -202,7 +205,8 @@
 			const diffPanel = document.getElementById('diffPanel');
 			const stepper = document.getElementById('stepper');
 			const progressBar = document.getElementById('progressBar');
-			const logContainer = document.getElementById('logContainer');
+                        const logContainer = document.getElementById('logContainer');
+                        const logContent = document.getElementById('logContent');
 			const toggleLogBtn = document.getElementById('toggleLogBtn');
 			const copyLogBtn = document.querySelector('.copyLogBtn');
 			const downloadLogBtn = document.querySelector('.downloadLogBtn');
@@ -218,19 +222,19 @@
 				d.addEventListener('mousedown', e=>initDrag(e, d));
 			});
 			let logCollapsed = window.sessionStorage.getItem('LOG_COLLAPSED') === 'true';
-			function updateLogVisibility(){
-				if(logCollapsed){
-					logContainer.style.display='none';
-					let dv = logContainer.previousElementSibling;
-					if(dv && dv.classList.contains('divider')) dv.style.display='none';
-					toggleLogBtn.textContent='Show Log';
-				}else{
-					logContainer.style.display='';
-					let dv = logContainer.previousElementSibling;
-					if(dv && dv.classList.contains('divider')) dv.style.display='';
-					toggleLogBtn.textContent='Hide Log';
-				}
-			}
+                        function updateLogVisibility(){
+                                if(logCollapsed){
+                                        logContent.style.display='none';
+                                        let dv = logContainer.previousElementSibling;
+                                        if(dv && dv.classList.contains('divider')) dv.style.display='none';
+                                        toggleLogBtn.textContent='Show Log';
+                                }else{
+                                        logContent.style.display='';
+                                        let dv = logContainer.previousElementSibling;
+                                        if(dv && dv.classList.contains('divider')) dv.style.display='';
+                                        toggleLogBtn.textContent='Hide Log';
+                                }
+                        }
 			updateLogVisibility();
 			toggleLogBtn.onclick = ()=>{
 				logCollapsed = !logCollapsed;


### PR DESCRIPTION
## Summary
- wrap log panel sections in `#logContent`
- toggle visibility on `#logContent` instead of the entire container
- keep the toggle button visible and adjust CSS layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685800cf5ccc8331a5d47899801ec43a