### PR TITLE
Collapse debug log panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,9 +206,11 @@
 			const copyHtmlBtn = document.getElementById('copyHtmlBtn');
 			const downloadHtmlBtn = document.getElementById('downloadHtmlBtn');
 			const toggleDiffBtn = document.getElementById('toggleDiffBtn');
-			const diffPanel = document.getElementById('diffPanel');
-			const stepper = document.getElementById('stepper');
-			const progressBar = document.getElementById('progressBar');
+                        const diffPanel = document.getElementById('diffPanel');
+                        const stepper = document.getElementById('stepper');
+                        const progressBar = document.getElementById('progressBar');
+                        const editorContainer = document.getElementById('editorContainer');
+                        const previewContainer = document.getElementById('previewContainer');
 			const logContainer = document.getElementById('logContainer');
 			const logContent = document.getElementById('logContent');
 			const toggleLogBtn = document.getElementById('toggleLogBtn');
@@ -227,19 +229,31 @@
 			});
                         let logCollapsed = window.sessionStorage.getItem('LOG_COLLAPSED') === 'true';
                         showDebugLogInput.checked = !logCollapsed;
-			function updateLogVisibility(){
-				if(logCollapsed){
-					logContent.style.display='none';
-					let dv = logContainer.previousElementSibling;
-					if(dv && dv.classList.contains('divider')) dv.style.display='none';
-					toggleLogBtn.textContent='Show Log';
-				}else{
-					logContent.style.display='';
-					let dv = logContainer.previousElementSibling;
-					if(dv && dv.classList.contains('divider')) dv.style.display='';
-					toggleLogBtn.textContent='Hide Log';
-				}
-			}
+                        let savedLogFlex = '';
+                        let savedPrevFlex = '';
+                        let savedEditorFlex = '';
+                        function updateLogVisibility(){
+                                const divider = logContainer.previousElementSibling;
+                                if(logCollapsed){
+                                        logContent.style.display = 'none';
+                                        savedLogFlex = logContainer.style.flex;
+                                        savedPrevFlex = previewContainer.style.flex;
+                                        savedEditorFlex = editorContainer.style.flex;
+                                        logContainer.style.display = 'none';
+                                        if(divider && divider.classList.contains('divider')) divider.style.display = 'none';
+                                        previewContainer.style.flex = '';
+                                        editorContainer.style.flex = '';
+                                        toggleLogBtn.textContent = 'Show Log';
+                                } else {
+                                        logContent.style.display = '';
+                                        logContainer.style.display = '';
+                                        if(divider && divider.classList.contains('divider')) divider.style.display = '';
+                                        if(savedLogFlex) logContainer.style.flex = savedLogFlex;
+                                        if(savedPrevFlex) previewContainer.style.flex = savedPrevFlex;
+                                        if(savedEditorFlex) editorContainer.style.flex = savedEditorFlex;
+                                        toggleLogBtn.textContent = 'Hide Log';
+                                }
+                        }
 			updateLogVisibility();
                         toggleLogBtn.onclick = ()=>{
                                 logCollapsed = !logCollapsed;


### PR DESCRIPTION
## Summary
- capture editor/preview container elements
- hide `#logContainer` and preceding divider when collapsed
- restore panel size on toggle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68580b237cac8331979f3de6f96af4f5